### PR TITLE
Remove other layers rather than hiding them

### DIFF
--- a/export_layers.py
+++ b/export_layers.py
@@ -143,7 +143,7 @@ class LayerExport(inkex.Effect):
             if layer.attrib['id'] in export.visible_layers:
                 layer.attrib['style'] = 'display:inline'
             else:
-                layer.attrib['style'] = 'display:none'
+                document.getroot().remove(layer)
 
         output_file = os.path.join(output_dir, export.file_name + '.svg')
         document.write(output_file)


### PR DESCRIPTION
Thank you for working on this extension; it's a life saver!

I find that it just hides the "unneeded layers" when exporting to SVG. I can see at least three potential problems with this:

1. Large file sizes, especially if the design is large and/or needs to be put online.
2. Some tools may not understand `display:none`, like FontForge.
3. Privacy issues, as the user is not aware that _all the layers_ end up in every exported file.

This PR solves that by removing other layers when exporting instead of hiding them.